### PR TITLE
🐛 Fix atrium-sud CAS

### DIFF
--- a/src/cas/atrium-sud.js
+++ b/src/cas/atrium-sud.js
@@ -11,7 +11,7 @@ async function login(url, account, username, password)
 
     let lt = dom.window.document.getElementsByName('lt');
     let execution = dom.window.document.getElementsByName('execution');
-    lt = lt[0].value;
+    lt = lt[0]?.value;
     execution = execution[0].value;
 
     dom = await getDOM({


### PR DESCRIPTION
J'avais une erreur avec le CAS atrium-sud

```
TypeError: Cannot read property 'value' of undefined
    at Object.login [as atrium-sud] (node_modules\pronote-api\src\cas\atrium-sud.js:14:16)
```

Je n'ai pas retiré la ligne qui posait problème au cas où Atrium déciderai de faire marche arrière sur ces changements...